### PR TITLE
UPDATE project.godot TO VERSION 4.3 YOU OUTDATED F

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,6 +12,6 @@ config_version=5
 
 config/name="Component based joshening"
 run/main_scene="res://godot/com/joshgamedevelopment/scenes/main/world/world.tscn"
-config/features=PackedStringArray("4.2", "Forward Plus")
+config/features=PackedStringArray("4.3", "Forward Plus")
 boot_splash/image="res://icon.svg"
 config/icon="res://icon.svg"


### PR DESCRIPTION
This pull request includes a small change to the `project.godot` file. The change updates the `config/features` to use version "4.3" instead of "4.2".

* [`project.godot`](diffhunk://#diff-88c173602c6c7ccaaba6f408d21c235bda4d6884e30e71e73e1b07b9f93ad7b6L15-R15): Updated `config/features` to `PackedStringArray("4.3", "Forward Plus")` from `PackedStringArray("4.2", "Forward Plus")`.
